### PR TITLE
vertical tweets

### DIFF
--- a/lib/parking_tweets/tweet.ex
+++ b/lib/parking_tweets/tweet.ex
@@ -11,16 +11,7 @@ defmodule ParkingTweets.Tweet do
     {garages_with_status, garages_without_status} = Enum.split_with(statuses, &Garage.status?/1)
     all_statuses = Enum.flat_map([garages_with_status, garages_without_status], &status_texts/1)
 
-    garage_statuses =
-      case all_statuses do
-        [long_status] ->
-          long_status
-
-        [long_status | short_statuses] ->
-          [long_status, "; " | Enum.intersperse(short_statuses, ", ")]
-      end
-
-    ["#Parking Update: ", garage_statuses, "."]
+    ["#Parking Update\n\n", Enum.intersperse(Enum.sort(all_statuses), "\n")]
   end
 
   defp status_texts([garage | rest]) do

--- a/lib/parking_tweets/updated_garages.ex
+++ b/lib/parking_tweets/updated_garages.ex
@@ -47,7 +47,7 @@ defmodule ParkingTweets.UpdatedGarages do
     tweet =
       state.current
       |> GarageMap.difference(state.previous)
-      |> Enum.sort_by(&Garage.utilization_percent/1, &>=/2)
+      |> Enum.sort_by(& &1.name)
       |> Tweet.from_garages()
 
     Logger.info(fn ->

--- a/lib/parking_tweets/updated_garages.ex
+++ b/lib/parking_tweets/updated_garages.ex
@@ -44,11 +44,14 @@ defmodule ParkingTweets.UpdatedGarages do
   end
 
   def send_tweet(state, time) do
+    {:ok, local_time} =
+      FastLocalDatetime.unix_to_datetime(System.system_time(:seconds), "America/New_York")
+
     tweet =
       state.current
       |> GarageMap.difference(state.previous)
       |> Enum.sort_by(& &1.name)
-      |> Tweet.from_garages()
+      |> Tweet.from_garages(local_time)
 
     Logger.info(fn ->
       "Sending Tweet: #{tweet}"

--- a/mix.exs
+++ b/mix.exs
@@ -31,6 +31,7 @@ defmodule ParkingTweets.MixProject do
       {:server_sent_event_stage, "~> 0.1"},
       {:jason, "~> 1.0"},
       {:extwitter, "~> 0.9"},
+      {:fast_local_datetime, "~> 0.1"},
       {:credo, "~> 0.9", only: [:dev, :test]},
       {:excoveralls, "~> 0.8", only: [:dev, :test]},
       {:distillery, "~> 1.5", only: [:dev, :prod]}

--- a/mix.lock
+++ b/mix.lock
@@ -9,6 +9,7 @@
   "excoveralls": {:hex, :excoveralls, "0.8.2", "b941a08a1842d7aa629e0bbc969186a4cefdd035bad9fe15d43aaaaaeb8fae36", [:mix], [{:exjsx, ">= 3.0.0", [hex: :exjsx, repo: "hexpm", optional: false]}, {:hackney, ">= 0.12.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "exjsx": {:hex, :exjsx, "4.0.0", "60548841e0212df401e38e63c0078ec57b33e7ea49b032c796ccad8cde794b5c", [:mix], [{:jsx, "~> 2.8.0", [hex: :jsx, repo: "hexpm", optional: false]}], "hexpm"},
   "extwitter": {:hex, :extwitter, "0.9.3", "7c93305bd6928bfc3566f91d751275c9408701031e76ae9f250711d4a5e1a6a0", [:mix], [{:oauther, "~> 1.1", [hex: :oauther, repo: "hexpm", optional: false]}, {:poison, "~> 3.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
+  "fast_local_datetime": {:hex, :fast_local_datetime, "0.1.0", "427979badddb6889c75e01ae89a2811fe48dd310f0e64194299c0e267706cfb7", [:mix], [{:tzdata, "~> 0.5", [hex: :tzdata, repo: "hexpm", optional: false]}], "hexpm"},
   "gen_stage": {:hex, :gen_stage, "0.13.1", "edff5bca9cab22c5d03a834062515e6a1aeeb7665fb44eddae086252e39c4378", [:mix], [], "hexpm"},
   "hackney": {:hex, :hackney, "1.12.1", "8bf2d0e11e722e533903fe126e14d6e7e94d9b7983ced595b75f532e04b7fdc7", [:rebar3], [{:certifi, "2.3.1", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "5.1.1", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
   "httpoison": {:hex, :httpoison, "1.1.1", "96ed7ab79f78a31081bb523eefec205fd2900a02cda6dbc2300e7a1226219566", [:mix], [{:hackney, "~> 1.8", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
@@ -25,5 +26,6 @@
   "ranch": {:hex, :ranch, "1.3.2", "e4965a144dc9fbe70e5c077c65e73c57165416a901bd02ea899cfd95aa890986", [:rebar3], [], "hexpm"},
   "server_sent_event_stage": {:hex, :server_sent_event_stage, "0.1.0", "52757a2b2675a254ec5fba220e76cd65681ea4b212b9adcdb9852b90c98d2f96", [:mix], [{:ex_doc, "~> 0.18", [hex: :ex_doc, repo: "hexpm", optional: true]}, {:gen_stage, "~> 0.13", [hex: :gen_stage, repo: "hexpm", optional: false]}, {:httpoison, "~> 1.1", [hex: :httpoison, repo: "hexpm", optional: false]}], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
+  "tzdata": {:hex, :tzdata, "0.5.16", "13424d3afc76c68ff607f2df966c0ab4f3258859bbe3c979c9ed1606135e7352", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"},
 }

--- a/semaphore/deploy.sh
+++ b/semaphore/deploy.sh
@@ -27,7 +27,7 @@ function task_count_eq {
 }
 
 function exit_if_too_many_checks {
-  if [[ $checks -ge 12 ]]; then
+  if [[ $checks -ge 30 ]]; then
     exit 1
   fi
   sleep 5

--- a/test/parking_tweets/tweet_test.exs
+++ b/test/parking_tweets/tweet_test.exs
@@ -6,11 +6,11 @@ defmodule ParkingTweets.TweetTest do
 
   describe "from_garages/1" do
     test "uses status when available" do
-      assert_tweet_like([garage(status: "FULL")], "Garage is FULL.")
+      assert_tweet_like([garage(status: "FULL")], "Garage is FULL")
     end
 
     test "uses free spots and percentage" do
-      assert_tweet_like([garage(utilization: 901)], "Garage has 99 free spaces (90% full).")
+      assert_tweet_like([garage(utilization: 901)], "Garage has 99 free spaces (90% full)")
     end
 
     test "with multiple garages with status, simplifies the latter ones" do
@@ -51,7 +51,7 @@ defmodule ParkingTweets.TweetTest do
       tweet = IO.iodata_to_binary(from_garages(garages))
 
       assert tweet ==
-               "#Parking Update: Garage has 1000 free spaces (0% full); Garage: 1000 (0%), Garage: 1000 (0%)."
+               "#Parking Update\n\nGarage has 1000 free spaces (0% full)\nGarage: 1000 (0%)\nGarage: 1000 (0%)"
     end
   end
 

--- a/test/parking_tweets/tweet_test.exs
+++ b/test/parking_tweets/tweet_test.exs
@@ -6,11 +6,14 @@ defmodule ParkingTweets.TweetTest do
 
   describe "from_garages/1" do
     test "uses status when available" do
-      assert_tweet_like([garage(status: "FULL")], "Garage is FULL")
+      assert_tweet_like([garage(status: "FULL")], ": Garage is FULL.")
     end
 
     test "uses free spots and percentage" do
-      assert_tweet_like([garage(utilization: 901)], "Garage has 99 free spaces (90% full)")
+      assert_tweet_like(
+        [garage(utilization: 901)],
+        ": Garage has 99 free spaces (90% full)."
+      )
     end
 
     test "with multiple garages with status, simplifies the latter ones" do
@@ -19,6 +22,7 @@ defmodule ParkingTweets.TweetTest do
         garage(name: "Other", status: "VERY FULL")
       ]
 
+      assert_tweet_like(garages, "Garage: FULL")
       assert_tweet_like(garages, "Other: VERY FULL")
     end
 
@@ -29,7 +33,7 @@ defmodule ParkingTweets.TweetTest do
         garage()
       ]
 
-      assert_tweet_like(garages, "Garage has 1000 free spaces (0% full)")
+      assert_tweet_like(garages, "Garage: 1000 free spaces (0% full)")
     end
 
     test "with multiple garages, simplifies the free space text" do
@@ -51,7 +55,7 @@ defmodule ParkingTweets.TweetTest do
       tweet = IO.iodata_to_binary(from_garages(garages))
 
       assert tweet ==
-               "#Parking Update\n\nGarage has 1000 free spaces (0% full)\nGarage: 1000 (0%)\nGarage: 1000 (0%)"
+               "#Parking Availability\n\nGarage: 1000 free spaces (0% full)\nGarage: 1000 (0%)\nGarage: 1000 (0%)"
     end
   end
 

--- a/test/parking_tweets/updated_garages_test.exs
+++ b/test/parking_tweets/updated_garages_test.exs
@@ -63,12 +63,12 @@ defmodule ParkingTweets.UpdatedGaragesTest do
   end
 
   describe "send_tweet/2" do
-    test "sends the tweet with higher-utilization garages first", %{state: state} do
+    test "sends the tweet with alphabetized names", %{state: state} do
       current =
         Enum.reduce(
           [
-            low = %Garage{id: "low", name: "Low", utilization: 100, capacity: 200},
-            high = %Garage{id: "high", name: "High", utilization: 100, capacity: 100}
+            b = %Garage{id: "B", name: "B", utilization: 100, capacity: 100},
+            a = %Garage{id: "A", name: "A", utilization: 50, capacity: 100}
           ],
           state.current,
           fn garage, map -> GarageMap.put(map, garage) end
@@ -79,7 +79,7 @@ defmodule ParkingTweets.UpdatedGaragesTest do
       assert new_state.previous == state.current
       assert new_state.last_tweet_at == 100
       assert_receive {:tweet, text}
-      assert text == IO.iodata_to_binary(Tweet.from_garages([high, low]))
+      assert text == IO.iodata_to_binary(Tweet.from_garages([a, b]))
     end
 
     test "after receiving an update, sends a tweet with the updated garage", %{state: state} do

--- a/test/parking_tweets/updated_garages_test.exs
+++ b/test/parking_tweets/updated_garages_test.exs
@@ -3,7 +3,7 @@ defmodule ParkingTweets.UpdatedGaragesTest do
   use ExUnit.Case, async: true
   import ParkingTweets.UpdatedGarages
   alias ServerSentEventStage.Event
-  alias ParkingTweets.{GarageMap, Garage, Tweet}
+  alias ParkingTweets.{GarageMap, Garage}
 
   setup do
     {:consumer, state, []} = init([])
@@ -67,8 +67,8 @@ defmodule ParkingTweets.UpdatedGaragesTest do
       current =
         Enum.reduce(
           [
-            b = %Garage{id: "B", name: "B", utilization: 100, capacity: 100},
-            a = %Garage{id: "A", name: "A", utilization: 50, capacity: 100}
+            %Garage{id: "B", name: "B", utilization: 100, capacity: 100},
+            %Garage{id: "A", name: "A", utilization: 50, capacity: 100}
           ],
           state.current,
           fn garage, map -> GarageMap.put(map, garage) end
@@ -79,7 +79,7 @@ defmodule ParkingTweets.UpdatedGaragesTest do
       assert new_state.previous == state.current
       assert new_state.last_tweet_at == 100
       assert_receive {:tweet, text}
-      assert text == IO.iodata_to_binary(Tweet.from_garages([a, b]))
+      assert text =~ "A: 50 free spaces"
     end
 
     test "after receiving an update, sends a tweet with the updated garage", %{state: state} do


### PR DESCRIPTION
before:
```
#Parking Update: Salem has 191 free spaces (72% full); Beverly: 191 (61%), 
Route 128: 1009 (58%).
```
after:
```
#Parking Availability @ 6:04 AM

Alewife: 2113 free spaces (15% full)
Braintree: 832 (36%)
Quincy Adams: 1897 (12%)
Route 128: 1775 (26%)
Salem: 642 (8%)
```