### PR TITLE
fix: don't try to install awscli manually

### DIFF
--- a/semaphore/deploy.sh
+++ b/semaphore/deploy.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -e -u
 
-sudo pip install -U awscli
-
 # bash script should be called with aws environment ($APP-dev / $APP-dev-green / $APP-prod)
 # other required configuration:
 # * APP


### PR DESCRIPTION
Per the Semaphore docs, the new Ubuntu 18.04 platform already has
awscli installed. This step is currently causing the build to fail due
to Python version issues. I tried using `sem-version` but that didn't
help, perhaps because `pip` was being run with `sudo`. I can try
deploying this branch directly to prod tomorrow and seeing if it works
before merging.